### PR TITLE
Update Redis default port in Redis.md

### DIFF
--- a/cheat-sheet/DevOps Services/Redis.md
+++ b/cheat-sheet/DevOps Services/Redis.md
@@ -9,9 +9,9 @@ for sysadmins.
 #### CLI
 
 First thing to know is that you can use "telnet" (usually on Redis
-default port 6397)
+default port 6379)
 
-    telnet localhost 6397
+    telnet localhost 6379
 
 or the Redis CLI client
 


### PR DESCRIPTION
Hi, there is a small typo in the first paragraph of the Redis.md file. The default port is supposed to be `6379` instead of `6397`.
This PR fixes that :).
Awesome work by the way!