### PR TITLE
Use same syntax for read and write in go

### DIFF
--- a/examples/Go Examples/Go Channels.html
+++ b/examples/Go Examples/Go Channels.html
@@ -12,9 +12,9 @@ To read from a Go channel use the "&lt;-" operator
 
 <h3>Writing to Go Channels</h3>
 
-To write to a Go channel use "write()"
+You can write to Go Channels using the same "&lt;-" operator. 
 
-<pre>write(my_pipe, 1000)</pre>
+<pre>my_pipe <- "1000"</pre>
 
 <h3>Don't write on closed channels</h3>
 


### PR DESCRIPTION
It seems more intuitive to have the same syntax for writing and reading. 
Besides I was trying to look the function up online and could not find the function `write` anywhere.

Example : 
https://play.golang.org/p/1A8beWZkzZb