### PR TITLE
Cheatsheet JQ Add extra method for deep value extraction

### DIFF
--- a/cheat-sheet/Scripting/jq.md
+++ b/cheat-sheet/Scripting/jq.md
@@ -52,6 +52,10 @@ If you want to combine subkeys at different levels it won't work like this
 
 Instead you can access values like this
 
+    jq '.items[] | { "created" : .metadata["created"], name }'
+
+Or like this
+
     jq '.items[] | .metadata["created"], .name'
 
 The drawback being, that you do not get a JSON output, but each value on a new line.


### PR DESCRIPTION
Added an additional method for deep value extraction.

```bash
echo '{
  "items": [
    {
      "name": "test",
      "metadata": {
        "created": "2020"
      }
    }
  ]
}' | jq '.items[] | {"created": .metadata["created"], name }'

{
  "created": "2020",
  "name": "test"
}
```