### PR TITLE
jq: array concatenation requires arrays

### DIFF
--- a/cheat-sheet/Scripting/jq.md
+++ b/cheat-sheet/Scripting/jq.md
@@ -122,7 +122,7 @@ Adding elements to lists
 For example merge three object lists:
 
     echo '[ {"a":1}, {"b":2} ]' | \
-    jq --argjson input1 '{ "c":3 }' \
+    jq --argjson input1 '[ { "c":3 } ]' \
 	   --argjson input2 '[ { "d":4 }, { "e": 5} ]' \
 	   '. = $input1 + . +  $input2'
 


### PR DESCRIPTION
The original example results in an error with message:

    jq: error (at <stdin>:1): object ({"c":3}) and array ([{"a":1},{"...) cannot be added

Use three arrays as input data to allow concatenation.
(Tested with jq version jq-1.5-1-a5b5cbe.)