### PR TITLE
jq: escape backslash to allow interpretation

### DIFF
--- a/cheat-sheet/Scripting/jq.md
+++ b/cheat-sheet/Scripting/jq.md
@@ -46,7 +46,7 @@ Filter this by attribute
     jq '.results[] | select(.name == "John") | {age}'          # Get age for 'John'
     jq '.results[] | select((.name == "Joe") and (.age = 10))' # Get complete records for all 'Joe' aged 10
     jq '.results[] | select(.name | contains("Jo"))'           # Get complete records for all names with 'Jo'
-    jq '.results[] | select(.name | test("Joe\s+Smith"))'      # Get complete records for all names matching PCRE regex 'Joe\+Smith'
+    jq '.results[] | select(.name | test("Joe\\s+Smith"))'      # Get complete records for all names matching PCRE regex 'Joe\+Smith'
 
 Avoid `null` output when accessing non-existing keys
 


### PR DESCRIPTION
The backslash in `\s+` [needs to be escaped](https://github.com/stedolan/jq/wiki/FAQ#support-for-regular-expressions) to `\\s+` such that it's a proper JSON string that can be accepted and interpreted as a regular expression.

Without escaping, you get an error:
```sh
$ jq '.results[] | select(.name | test("Joe\s+Smith"))' file.json
jq: error: Invalid escape at line 1, column 4 (while parsing '"\s"') at <top-level>, line 1:
.results[] | select(.name | test("Joe\s+Smith"))
jq: 1 compile error
```

With escaping, you don't:
```sh
$ jq '.results[] | select(.name | test("Joe\\s+Smith"))' file.json
{
  "name": "Joe Smith",
  "age": 10,
  "city": "TownB"
}
{
  "name": "Joe   Smith",
  "age": 10,
  "city": "TownB"
}
```